### PR TITLE
Adicionado Meta-Informações no template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,13 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0"/>
+        <meta http-equiv="content-language" content="pt-br">
+        <meta name="robots" content="index, follow">
+        <meta name="description" content="{{ META_DESCRIPTION }}"/>
+        <meta name="keywords" content="{{ META_KEYWORDS|join(', ') }}"/>
+        <meta name="author" content="{{ AUTHOR }}">
+        <meta name="generator" content="Feito com Materialize, Pelican,
+        Python e VIM. ">
         <title>{% block title %}{{ SITENAME }}{% endblock %}</title>
 
         <!-- Feeds -->


### PR DESCRIPTION
Junto com o pull request (https://github.com/grupydf/grupydf.github.io/pull/35) que define as configurações de meta tags, aqui ele utiliza essas configurações para exibir no template. Atendendo à issue: https://github.com/grupydf/grupydf.github.io/issues/3
