### PR TITLE
Resolvido bug que quebrava links externos nas seções da home

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -49,3 +49,10 @@ def GET_ARTICLE_IMAGE(article, root):
 def GET_ARTICLE_AT_GITHUB(article, repo, branch):
     base = posixpath.relpath(article.source_path, os.getcwd())
     return posixpath.join(repo, 'tree/', branch, base)
+
+
+def GET_LINK(link):
+    if link.startswith('http://') or link.startswith('https://'):
+        return link
+    else:
+        return '/' + link

--- a/templates/home.html
+++ b/templates/home.html
@@ -45,7 +45,7 @@
                             {% if 'buttons' in item %}
                             <div class="center">
                                 {% for button in item['buttons'] %}
-                                <a class="{{ MALT_BASE_COLOR }} waves-effect waves-light btn" href="/{{ button['href'] }}">{{ button['text'] }}</a>
+                                <a class="{{ MALT_BASE_COLOR }} waves-effect waves-light btn" href="{{ GET_LINK(button['href']) }}">{{ button['text'] }}</a>
                                 {% endfor %}
                             </div>
                             {% endif %}


### PR DESCRIPTION
Verificando o site do http://pynorte.python.org.br/ vi que a home possuía um bug:  O link para entrar no grupo no telegram era exibo como um link interno.

``` python
{
                "title": "Entre em Contato",
                "icon": "fa-paper-plane",
                "text": "Deseja participar? Sugerir uma atividade ou simplesmente acompanhar o grupo?"
                        " Contacte-nos via Telegram.",
                "buttons": [
                    {
                        "text": "Telegram",
                        "href": "https://telegram.me/joinchat/COYq6QM8RkebVUVK1WxRHQ",
                    },
                           ]
            }

```

Na hora de renderizar o malt estava tratando o 'href' como link interno e colocando '/' antes do link.

Fiz então uma função para verificar se o link é interno (colocando o '/' no início) ou não, e troquei o '/' do template pela chamada da função.
